### PR TITLE
Ignore AreaWarningMods.txt when updating

### DIFF
--- a/GitUpdateConfig.txt
+++ b/GitUpdateConfig.txt
@@ -11,3 +11,4 @@ LICENSE
 config.ini
 .config
 .pdb
+AreaWarningMods.txt


### PR DESCRIPTION
When using the update plugin the file is recognized as being changed. As the file is created by the plugin we can ignore it in the GitUpdateConfig.txt.